### PR TITLE
Make compatible with WPGraphQL for GF v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ This outputs the form that has been set up in WordPress - Gravity Forms. Ready f
 
 Tutorial on setup: https://thoughtsandstuff.com/headless-wordpress-gravity-forms-with-gatsby-step-by-step-tutorial/
 
+### Passing in Preset Values
+
+Sometimes you will want to conditionally set default values, or pass in data to hidden fields. This could be values for a user ID, or a current page.
+
+This is handled by the `presetValues` prop.
+
+```js
+<GravityFormForm data={form} presetValues={{ input_2: "My preset value" }} />
+```
+
+In the above example `input_2` corresponds to the 2nd field added in the WordPress Gravity Forms edit page. This value can be found by clicking on the field and looking at the top right just under Field Settings.
+
 ## WordPress Backend Not Allowing Submission
 
 Having CORS issues?

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The `...GravityFormFields` fragment is included within the gatsby-plugin-gravity
 
 This outputs the form that has been set up in WordPress - Gravity Forms. Ready for you to style it!
 
+Tutorial on setup: https://thoughtsandstuff.com/headless-wordpress-gravity-forms-with-gatsby-step-by-step-tutorial/
+
 ## WordPress Backend Not Allowing Submission
 
 Having CORS issues?

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm i gatsby-plugin-gravity-forms
 },
 ```
 
-2. Import the component and use it with a GraphQL query. Make sure to set the formID.
+2. Import the component and use it with a GraphQL query. Make sure to set the form ID as `databaseId`.
 
 ```js
 import React from "react";
@@ -45,7 +45,7 @@ import GravityFormForm from "gatsby-plugin-gravity-forms";
 const ExamplePage = () => {
   const data = useStaticQuery(graphql`
     query formQuery {
-      wpGravityFormsForm(formId: { eq: 1 }) {
+      wpGfForm(databaseId: { eq: 1 }) {
         ...GravityFormFields
       }
     }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "react": "^17.0.2"
   },
   "peerDependencies": {
-    "gatsby": "^3.0.0"
+    "gatsby": "^4.4.0"
   }
 }

--- a/src/components/Captcha/index.js
+++ b/src/components/Captcha/index.js
@@ -85,29 +85,15 @@ export const CaptchaField = graphql`
     captchaTheme
     captchaType
     conditionalLogic {
-      rules {
-        fieldId
-        operator
-        value
-      }
-      actionType
-      logicType
+      ...ConditionalLogic
     }
     cssClass
     description
     descriptionPlacement
-    displayOnly
     errorMessage
-    formId
-    id
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    pageNumber
     simpleCaptchaBackgroundColor
     simpleCaptchaFontColor
     simpleCaptchaSize
-    size
-    type
   }
 `;

--- a/src/components/Html/index.js
+++ b/src/components/Html/index.js
@@ -43,25 +43,11 @@ Html.propTypes = {
 export const HtmlField = graphql`
   fragment HtmlField on WpHtmlField {
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     content
     cssClass
-    disableMargins
-    displayOnly
-    formId
-    id
+    hasMargins
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    pageNumber
-    size
-    type
   }
 `;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -97,59 +97,39 @@ Input.propTypes = {
 
 export const TextField = graphql`
   fragment TextField on WpTextField {
-    id
+    adminLabel
+    autocompleteAttribute
+    canPrepopulate
+    conditionalLogic {
+      ...ConditionalLogic
+    }
     cssClass
-    errorMessage
     defaultValue
     description
     descriptionPlacement
-    visibility
-    value
-    type
-    size
-    placeholder
-    pageNumber
-    noDuplicates
-    maxLength
-    layoutSpacerGridColumnSpan
-    layoutGridColumnSpan
-    label
+    errorMessage
+    hasAutocomplete
     inputName
+    isPasswordInput
     isRequired
-    formId
-    enablePasswordInput
-    enableAutocomplete
-    autocompleteAttribute
-    allowsPrepopulate
-    adminOnly
-    adminLabel
-    conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
-    }
+    label
+    maxLength
+    placeholder
+    shouldAllowDuplicates
+    size
+    value
   }
 `;
 
 export const DateField = graphql`
   fragment DateField on WpDateField {
+
     adminLabel
-    adminOnly
-    allowsPrepopulate
     calendarIconType
     calendarIconUrl
+    canPrepopulate
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     dateFormat
@@ -158,8 +138,6 @@ export const DateField = graphql`
     description
     descriptionPlacement
     errorMessage
-    formId
-    id
     inputName
     inputs {
       customLabel
@@ -170,44 +148,26 @@ export const DateField = graphql`
     }
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    noDuplicates
-    pageNumber
     placeholder
-    size
+    shouldAllowDuplicates
     subLabelPlacement
-    type
     value
-    visibility
   }
 `;
 
 export const EmailField = graphql`
   fragment EmailField on WpEmailField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
-    autocompleteAttribute
+    canPrepopulate
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
-    defaultValue
     description
     descriptionPlacement
-    emailConfirmEnabled
-    enableAutocomplete
     errorMessage
-    formId
-    id
-    inputName
+    hasAutocomplete
+    hasEmailConfirmation
     inputs {
       autocompleteAttribute
       customLabel
@@ -219,42 +179,20 @@ export const EmailField = graphql`
     }
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    noDuplicates
-    pageNumber
     placeholder
+    shouldAllowDuplicates
     size
     subLabelPlacement
-    type
     value
-    visibility
   }
 `;
 
 export const HiddenField = graphql`
   fragment HiddenField on WpHiddenField {
-    allowsPrepopulate
-    conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
-    }
-    cssClass
+    canPrepopulate
     defaultValue
-    formId
-    id
     inputName
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    pageNumber
-    size
-    type
     value
   }
 `;
@@ -262,82 +200,54 @@ export const HiddenField = graphql`
 export const NumberField = graphql`
   fragment NumberField on WpNumberField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
     autocompleteAttribute
     calculationFormula
     calculationRounding
+    canPrepopulate
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     defaultValue
     description
     descriptionPlacement
-    enableAutocomplete
-    enableCalculation
     errorMessage
-    formId
-    id
+    hasAutocomplete
     inputName
+    isCalculation
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    noDuplicates
     numberFormat
-    pageNumber
     placeholder
     rangeMax
     rangeMin
+    shouldAllowDuplicates
     size
-    type
     value
-    visibility
   }
 `;
 
 export const PhoneField = graphql`
   fragment PhoneField on WpPhoneField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
     autocompleteAttribute
+    canPrepopulate
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     defaultValue
     description
     descriptionPlacement
-    enableAutocomplete
     errorMessage
-    formId
-    id
+    hasAutocomplete
     inputName
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    noDuplicates
-    pageNumber
     phoneFormat
     placeholder
+    shouldAllowDuplicates
     size
-    type
     value
-    visibility
   }
 `;

--- a/src/components/Multiselect/index.js
+++ b/src/components/Multiselect/index.js
@@ -70,39 +70,25 @@ Multiselect.propTypes = {
 export const MultiSelectField = graphql`
   fragment MultiSelectField on WpMultiSelectField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
+    canPrepopulate
     choices {
       isSelected
       text
       value
     }
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     description
     descriptionPlacement
-    enableChoiceValue
-    enableEnhancedUI
+    hasChoiceValue
+    hasEnhancedUI
     errorMessage
-    formId
-    id
     inputName
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    pageNumber
     size
-    type
     values
-    visibility
   }
 `;

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -71,45 +71,30 @@ Select.propTypes = {
 export const SelectField = graphql`
   fragment SelectField on WpSelectField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
     autocompleteAttribute
+    canPrepopulate
     choices {
       isSelected
       text
       value
     }
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     defaultValue
     description
     descriptionPlacement
-    enableAutocomplete
-    enableChoiceValue
-    enableEnhancedUI
-    enablePrice
     errorMessage
-    formId
-    id
+    hasAutocomplete
+    hasChoiceValue
+    hasEnhancedUI
     inputName
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    noDuplicates
-    pageNumber
     placeholder
+    shouldAllowDuplicates
     size
-    type
     value
-    visibility
   }
 `;

--- a/src/components/SelectorList/index.js
+++ b/src/components/SelectorList/index.js
@@ -96,8 +96,7 @@ SelectorList.propTypes = {
 export const CheckboxField = graphql`
   fragment CheckboxField on WpCheckboxField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
+    canPrepopulate
     checkboxValues {
       inputId
       value
@@ -108,45 +107,29 @@ export const CheckboxField = graphql`
       value
     }
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     description
     descriptionPlacement
-    enableChoiceValue
-    enablePrice
-    enableSelectAll
     errorMessage
-    formId
-    id
-    inputName
+    hasChoiceValue
+    hasSelectAll
     inputs {
       id
       label
       name
     }
+    inputName
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    pageNumber
-    size
-    type
-    visibility
   }
 `;
 
 export const RadioField = graphql`
   fragment RadioField on WpRadioField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
+    canPrepopulate
     choices {
       isOtherChoice
       isSelected
@@ -154,33 +137,18 @@ export const RadioField = graphql`
       value
     }
     conditionalLogic {
-      actionType
-      logicType
-      rules {
-        fieldId
-        operator
-        value
-      }
+      ...ConditionalLogic
     }
     cssClass
     description
     descriptionPlacement
-    enableChoiceValue
-    enableOtherChoice
-    enablePrice
+    hasChoiceValue
+    hasOtherChoice
     errorMessage
-    formId
-    id
     inputName
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
-    noDuplicates
-    pageNumber
-    size
-    type
+    shouldAllowDuplicates
     value
-    visibility
   }
 `;

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -93,8 +93,7 @@ Textarea.propTypes = {
 export const TextAreaField = graphql`
   fragment TextAreaField on WpTextAreaField {
     adminLabel
-    adminOnly
-    allowsPrepopulate
+    canPrepopulate
     conditionalLogic {
       actionType
       rules {
@@ -108,21 +107,14 @@ export const TextAreaField = graphql`
     description
     descriptionPlacement
     errorMessage
-    formId
-    id
     inputName
     isRequired
     label
-    layoutGridColumnSpan
-    layoutSpacerGridColumnSpan
     maxLength
-    noDuplicates
-    pageNumber
+    shouldAllowDuplicates
     placeholder
     size
-    type
-    useRichTextEditor
+    hasRichTextEditor
     value
-    visibility
   }
 `;

--- a/src/container/FieldBuilder/index.js
+++ b/src/container/FieldBuilder/index.js
@@ -25,7 +25,7 @@ const FieldBuilder = ({ formFields, formLoading, presetValues }) => {
       type,
       size,
       visibility,
-      formId,
+      databaseId,
     } = field;
 
     let inputWrapperClass = classnames(
@@ -46,7 +46,7 @@ const FieldBuilder = ({ formFields, formLoading, presetValues }) => {
       `gfield_visibility_${valueToLowerCase(visibility)}`
     );
 
-    const wrapId = `field_${formId}_${id}`;
+    const wrapId = `field_${databaseId}_${id}`;
 
     //TODO: Should this match GF version "input_form.id_input.id"
     const inputName = `input_${field.id}`;

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -1,15 +1,9 @@
 import { graphql } from 'gatsby'
 
 export const Button = graphql`
-    fragment Button on WpButton {
+    fragment Button on WpFormButton {
         conditionalLogic {
-            actionType
-            logicType
-            rules {
-                fieldId
-                operator
-                value
-            }
+            ...ConditionalLogic
         }
         imageUrl
         text
@@ -17,16 +11,22 @@ export const Button = graphql`
     }
 `
 
+export const ConditionalLogic = graphql`
+    fragment ConditionalLogic on WpConditionalLogic {
+        actionType
+        logicType
+        rules {
+            fieldId
+            operator
+            value
+        }
+    }
+`
+
 export const FormConfirmation = graphql`
     fragment FormConfirmation on WpFormConfirmation {
         conditionalLogic {
-            actionType
-            logicType
-            rules {
-                fieldId
-                operator
-                value
-            }
+            ...ConditionalLogic
         }
         id
         isDefault

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const GravityFormForm = ({
     labelPlacement,
     subLabelPlacement,
     formFields,
-    formId,
+    databaseId,
     title,
   } = form;
 
@@ -87,7 +87,7 @@ const GravityFormForm = ({
 
         submitForm({
           variables: {
-            formId: formId,
+            databaseId: databaseId,
             fieldValues: formRes,
           },
         })
@@ -136,18 +136,18 @@ const GravityFormForm = ({
   }
 
   return (
-    <div className="gform_wrapper" id={`gform_wrapper_${formId}`}>
-      <div className="gform_anchor" id={`gf_${formId}`} />
+    <div className="gform_wrapper" id={`gform_wrapper_${databaseId}`}>
+      <div className="gform_anchor" id={`gf_${databaseId}`} />
 
       <FormProvider {...methods}>
         <form
           className={
             loading
-              ? `gravityform gravityform--loading gravityform--id-${formId}`
-              : `gravityform gravityform--id-${formId}`
+              ? `gravityform gravityform--loading gravityform--id-${databaseId}`
+              : `gravityform gravityform--id-${databaseId}`
           }
-          id={`gfrom_${formId}`}
-          key={`gfrom_-${formId}`}
+          id={`gfrom_${databaseId}`}
+          key={`gfrom_-${databaseId}`}
           onSubmit={handleSubmit(onSubmitCallback)}
         >
           {generalError && <FormGeneralError errorCode={generalError} />}
@@ -163,7 +163,7 @@ const GravityFormForm = ({
                 `description_${valueToLowerCase(descriptionPlacement)}`,
                 `${valueToLowerCase(labelPlacement)}`
               )}
-              id={`gform_fields_${formId}`}
+              id={`gform_fields_${databaseId}`}
             >
               <FieldBuilder
                 formLoading={loading}
@@ -178,7 +178,7 @@ const GravityFormForm = ({
             <button
               className="gravityform__button gform_button button"
               disabled={loading}
-              id={`gform_submit_button_${formId}`}
+              id={`gform_submit_button_${databaseId}`}
               type="submit"
             >
               {loading ? (
@@ -212,13 +212,13 @@ GravityFormForm.defaultProps = {
 export default GravityFormForm;
 
 export const GravityFormFields = graphql`
-  fragment GravityFormFields on WpGravityFormsForm {
-    formId
-    title
+  fragment GravityFormFields on WpGfForm {
+    databaseId
     description
     descriptionPlacement
     labelPlacement
     subLabelPlacement
+    title
     button {
       ...Button
     }
@@ -227,21 +227,27 @@ export const GravityFormFields = graphql`
     }
     formFields {
       nodes {
+        displayOnly
         id
+        inputType
+        layoutGridColumnSpan
+        layoutSpacerGridColumnSpan
+        pageNumber
         type
+        visibility
         ...CaptchaField
         ...CheckboxField
         ...DateField
         ...EmailField
-        ...HtmlField
         ...HiddenField
+        ...HtmlField
         ...MultiSelectField
+        ...NumberField
+        ...PhoneField
         ...RadioField
         ...SelectField
         ...TextAreaField
         ...TextField
-        ...NumberField
-        ...PhoneField
       }
     }
   }

--- a/src/submitMutation.js
+++ b/src/submitMutation.js
@@ -1,11 +1,13 @@
 import { gql } from "@apollo/client";
 
 export default gql`
-  mutation submitForm($formId: Int!, $fieldValues: [FieldValuesInput]) {
-    submitGravityFormsForm(
-      input: { formId: $formId, fieldValues: $fieldValues }
+  mutation submitForm($databaseId: ID!, $fieldValues: [FieldValuesInput]) {
+    submitGfForm(
+      input: { id: $databaseId, fieldValues: $fieldValues }
     ) {
-      entryId
+      entry{
+        databaseId
+      }
       errors {
         id
         message


### PR DESCRIPTION
WPGraphQL for Gravity Forms v0.10.0 [contains a slew of schema changes](https://github.com/harness-software/wp-graphql-gravity-forms/releases/tag/v0.10.0) that are incompatible with `gatsby-plugin-gravity-forms`.

I've updated the graphql queries in this Draft PR, so `gatsby develop` can work, however:

1. I didnt touch or test the React components themselves (not my skillset).
2. Wasn't able to figure out the correlation between what you're querying vs using in those compoenents, so I didnt add new properties, only **removed**/changed existing ones.

So you probably need to update the components before merging.